### PR TITLE
Support GHC 8.4.3

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -24,9 +24,9 @@ dependencies:
 - async                >= 2.2.1 && < 2.3
 - bytestring           >= 0.10.8 && < 0.11
 - text                 >= 1.2.3 && < 1.3
-- binary               >= 0.8.6 && < 0.9
-- containers           >= 0.6.0 && < 0.7
-- stm                  >= 2.5.0 && < 2.6
+- binary               >= 0.8.5 && < 0.9
+- containers           >= 0.5.0 && < 0.7
+- stm                  >= 2.4.0 && < 2.6
 - attoparsec           >= 0.13.2 && < 0.14
 - conduit              >= 1.3.1 && < 1.4
 - conduit-extra        >= 1.3.0 && < 1.4

--- a/stack.yaml
+++ b/stack.yaml
@@ -37,7 +37,8 @@ packages:
 # Dependency packages to be pulled from upstream that are not in the resolver
 # using the same syntax as the packages field.
 # (e.g., acme-missiles-0.3)
-# extra-deps: []
+extra-deps:
+- QuickCheck-2.12.6.1
 
 # Override default flag values for local packages and extra-deps
 # flags: {}


### PR DESCRIPTION
This PR loosens the constraints such that this package compiles on resolver `lts-12.13` and GHC version `8.4.3`.

All tests pass as long as QuickCheck is fixed to be at least version `2.12` where the API was updated for the function `cover`.