### PR TITLE
Start packet identifiers from 1 instead of 0.

### DIFF
--- a/src/Network/MQTT/Client.hs
+++ b/src/Network/MQTT/Client.hs
@@ -145,7 +145,7 @@ pingPeriod = 30000000 -- 30 seconds
 runClientAppData :: ((AppData -> IO ()) -> IO ()) -> MQTTConfig -> IO MQTTClient
 runClientAppData mkconn MQTTConfig{..} = do
   ch <- newTChanIO
-  pid <- newTVarIO 0
+  pid <- newTVarIO 1
   thr <- newTVarIO []
   acks <- newTVarIO mempty
   st <- newTVarIO Starting


### PR DESCRIPTION
It appears that recent versions of Mosquitto refuse to accept packet identifiers starting from 0.  This means that the very first subscribe message sent from net-mqtt is refused, and the connection is closed.

This PR makes it so that the packet identifiers start from 1 instead of 0.  This makes mosquitto happy.

I tested this on two different versions of mosquitto, 1.6.2 and 1.5.8.  It appears that sending messages with a packet identifier of 0 works on 1.5.8, and no longer works on 1.6.2.  Sending messages with packet identifiers greater than 0 seems to work with both mosquitto versions I tested.  It also happens to be what the `mosquitto_sub` program does.

I'm not sure what the "official" version of the MQTT spec is, but here is the section describing "packet identifiers" (or "message identifiers") I found from some googling:

http://stanford-clark.com/MQTT/#msg-id

http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/errata01/os/mqtt-v3.1.1-errata01-os-complete.html#_Toc442180838

Here's the relevant sentence from the second link:

> SUBSCRIBE ... Control Packets MUST contain a **non-zero** 16-bit Packet Identifier.