### PR TITLE
Add query parameters to wss link

### DIFF
--- a/src/Network/MQTT/Client.hs
+++ b/src/Network/MQTT/Client.hs
@@ -207,7 +207,7 @@ tcpCompat mkconn = runMQTTConduit (adapt mkconn)
         adaptor ad = (appSource ad, appSink ad)
 
 runWS :: URI -> Bool -> MQTTConfig -> IO MQTTClient
-runWS uri secure cfg@MQTTConfig{..} = runMQTTConduit (adapt $ cf secure _hostname _port (uriPath uri) WS.defaultConnectionOptions hdrs) cfg
+runWS uri secure cfg@MQTTConfig{..} = runMQTTConduit (adapt $ cf secure _hostname _port ((++)<$>uriPath<*>uriQuery $ uri) WS.defaultConnectionOptions hdrs) cfg
   where
     hdrs = [("Sec-WebSocket-Protocol", "mqtt")]
     adapt mk f = mk (f . adaptor)


### PR DESCRIPTION
Thanks for adding websocket to the library.
I come across of scenario where query parameters are required in websocket path.
It looks safe to add them.