### PR TITLE
Changed fail to mqttFail

### DIFF
--- a/src/Network/MQTT/Client.hs
+++ b/src/Network/MQTT/Client.hs
@@ -161,7 +161,7 @@ connectURI cfg@MQTTConfig{..} uri = do
              "mqtts:" -> runClientTLS
              "ws:"    -> runWS uri False
              "wss:"   -> runWS uri True
-             us       -> fail $ "invalid URI scheme: " <> us
+             us       -> mqttFail $ "invalid URI scheme: " <> us
 
       (Just a) = uriAuthority uri
       (u,p) = up (uriUserInfo a)


### PR DESCRIPTION
Is this a missed `fail` which should be a `mqttFail` ?

Tried to compile with stackage resolver nightly-2020-01-08 and got (so not really related to the issue):

```
/Users/mputz/Projects/simpl-fant/workspace-hs/training/libs/mqtt-hs/src/Network/MQTT/Client.hs:164:26: error:
    • No instance for (MonadFail ((->) MQTTConfig))
        arising from a use of ‘fail’
    • In the expression: fail $ "invalid URI scheme: " <> us
      In a case alternative: us -> fail $ "invalid URI scheme: " <> us
      In the expression:
        case uriScheme uri of
          "mqtt:" -> runClient
          "mqtts:" -> runClientTLS
          "ws:" -> runWS uri False
          "wss:" -> runWS uri True
          us -> fail $ "invalid URI scheme: " <> us
    |
164 |              us       -> fail $ "invalid URI scheme: " <> us
    |            
```

