### PR TITLE
Bump QuickCheck version constraint

### DIFF
--- a/net-mqtt.cabal
+++ b/net-mqtt.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.3.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: bbec9368566c8aba114a497c47b9d18d7eeca200ba62ea31e69a77c1985828b2
+-- hash: df28c37c0351da3632da533b7f950cfaed800b319cbe18326e7721b35a98c068
 
 name:           net-mqtt
 version:        0.7.1.0
@@ -39,7 +39,7 @@ library
       src
   ghc-options: -Wall
   build-depends:
-      QuickCheck >=2.12.6.1 && <2.14
+      QuickCheck >=2.12.6.1 && <2.15
     , async >=2.2.1 && <2.3
     , attoparsec >=0.13.2 && <0.14
     , attoparsec-binary >=0.2 && <1.0
@@ -66,7 +66,7 @@ executable mqtt-example
       app/example
   ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
   build-depends:
-      QuickCheck >=2.12.6.1 && <2.14
+      QuickCheck >=2.12.6.1 && <2.15
     , async >=2.2.1 && <2.3
     , attoparsec >=0.13.2 && <0.14
     , attoparsec-binary >=0.2 && <1.0
@@ -94,7 +94,7 @@ executable mqtt-watch
       app/mqtt-watch
   ghc-options: -Wall -threaded -rtsopts -eventlog -with-rtsopts=-N
   build-depends:
-      QuickCheck >=2.12.6.1 && <2.14
+      QuickCheck >=2.12.6.1 && <2.15
     , async >=2.2.1 && <2.3
     , attoparsec >=0.13.2 && <0.14
     , attoparsec-binary >=0.2 && <1.0
@@ -125,7 +125,7 @@ test-suite mqtt-test
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       HUnit
-    , QuickCheck >=2.12.6.1 && <2.14
+    , QuickCheck >=2.12.6.1 && <2.15
     , async >=2.2.1 && <2.3
     , attoparsec >=0.13.2 && <0.14
     , attoparsec-binary >=0.2 && <1.0

--- a/package.yaml
+++ b/package.yaml
@@ -34,7 +34,7 @@ dependencies:
 - network-uri          >= 2.6.1 && < 2.7
 - attoparsec-binary    >= 0.2   && < 1.0
 - deepseq              >= 1.4.4.0 && < 1.5
-- QuickCheck           >= 2.12.6.1 && < 2.14
+- QuickCheck           >= 2.12.6.1 && < 2.15
 - websockets           >= 0.12.5.3 && < 0.13
 - connection           >= 0.2.0 && < 0.4
 


### PR DESCRIPTION
QuickCheck has a new version, so net-mqtt is currently marked as broken on nixpkgs.

- All tests pass when using stack while overriding the QuickCheck version
- I have built this commit against the latest nixpkgs-unstable with cabal2nix and had no problems