### PR TITLE
Relax deepseq bound to unblock builds with GHC 8.4

### DIFF
--- a/net-mqtt.cabal
+++ b/net-mqtt.cabal
@@ -50,7 +50,7 @@ library
     , conduit-extra >=1.3.0 && <1.4
     , connection >=0.2.0 && <0.4
     , containers >=0.5.0 && <0.7
-    , deepseq >=1.4.4.0 && <1.5
+    , deepseq >=1.4.3.0 && <1.5
     , network-conduit-tls >=1.3.2 && <1.4
     , network-uri >=2.6.1 && <2.7
     , stm >=2.4.0 && <2.6
@@ -77,7 +77,7 @@ executable mqtt-example
     , conduit-extra >=1.3.0 && <1.4
     , connection >=0.2.0 && <0.4
     , containers >=0.5.0 && <0.7
-    , deepseq >=1.4.4.0 && <1.5
+    , deepseq >=1.4.3.0 && <1.5
     , net-mqtt
     , network-conduit-tls >=1.3.2 && <1.4
     , network-uri >=2.6.1 && <2.7
@@ -105,7 +105,7 @@ executable mqtt-watch
     , conduit-extra >=1.3.0 && <1.4
     , connection >=0.2.0 && <0.4
     , containers >=0.5.0 && <0.7
-    , deepseq >=1.4.4.0 && <1.5
+    , deepseq >=1.4.3.0 && <1.5
     , net-mqtt
     , network-conduit-tls >=1.3.2 && <1.4
     , network-uri >=2.6.1 && <2.7
@@ -137,7 +137,7 @@ test-suite mqtt-test
     , conduit-extra >=1.3.0 && <1.4
     , connection >=0.2.0 && <0.4
     , containers >=0.5.0 && <0.7
-    , deepseq >=1.4.4.0 && <1.5
+    , deepseq >=1.4.3.0 && <1.5
     , net-mqtt
     , network-conduit-tls >=1.3.2 && <1.4
     , network-uri >=2.6.1 && <2.7

--- a/package.yaml
+++ b/package.yaml
@@ -33,7 +33,7 @@ dependencies:
 - network-conduit-tls  >= 1.3.2 && < 1.4
 - network-uri          >= 2.6.1 && < 2.7
 - attoparsec-binary    >= 0.2   && < 1.0
-- deepseq              >= 1.4.4.0 && < 1.5
+- deepseq              >= 1.4.3.0 && < 1.5
 - QuickCheck           >= 2.12.6.1 && < 2.15
 - websockets           >= 0.12.5.3 && < 0.13
 - connection           >= 0.2.0 && < 0.4


### PR DESCRIPTION
It seems `mqtt-hs` builds perfectly fine with GHC 8.4 except an overrestrictive bound for `deepseq` package. Could it please be relaxed?