### PR TITLE
Add toFilter

### DIFF
--- a/src/Network/MQTT/Topic.hs
+++ b/src/Network/MQTT/Topic.hs
@@ -14,7 +14,7 @@ Topic and topic related utiilities.
 
 module Network.MQTT.Topic (
   Filter, unFilter, Topic, unTopic, match,
-  mkFilter, mkTopic, split
+  mkFilter, mkTopic, split, toFilter
 ) where
 
 import           Data.String (IsString (..))
@@ -77,3 +77,7 @@ match (Filter pat) (Topic top) = cmp (splitOn "/" pat) (splitOn "/" top)
       | p == t = cmp ps ts
       | p == "+" && not ("$" `isPrefixOf` t) = cmp ps ts
       | otherwise = False
+
+-- | Convert a 'Topic' to a 'Filter' as all 'Topic's are valid 'Filter's
+toFilter :: Topic -> Filter
+toFilter (Topic t) = Filter t


### PR DESCRIPTION
In my use case, I frequently need to convert `Topic`s to `Filter`s. Since the recent change making these newtype wrappers instead of type synonyms (which I appreciated!), there is no sanctioned way to do this conversion without using `mkFilter` which introduces a `Maybe` that needs to be handled. In the case of `Topic` -> `Filter`, this conversion is always valid since all `Topic`s are valid `Filter`s, so one shouldn't need to go through `Maybe`.

Here, all I've done is add a very simple conversion function