### PR TITLE
Fix attoparsec version bounds

### DIFF
--- a/net-mqtt.cabal
+++ b/net-mqtt.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           net-mqtt
-version:        0.8.1.0
+version:        0.8.1.1
 synopsis:       An MQTT Protocol Implementation.
 description:    Please see the README on GitHub at <https://github.com/dustin/mqtt-hs#readme>
 category:       Network
@@ -39,7 +39,7 @@ library
   build-depends:
       QuickCheck >=2.12.6.1 && <2.15
     , async >=2.2.1 && <2.3
-    , attoparsec >=0.13.2 && <0.15
+    , attoparsec >=0.13.2 && <0.14
     , attoparsec-binary >=0.2 && <1.0
     , base >=4.7 && <5
     , binary >=0.8.5 && <0.9
@@ -66,7 +66,7 @@ executable mqtt-example
   build-depends:
       QuickCheck >=2.12.6.1 && <2.15
     , async >=2.2.1 && <2.3
-    , attoparsec >=0.13.2 && <0.15
+    , attoparsec >=0.13.2 && <0.14
     , attoparsec-binary >=0.2 && <1.0
     , base >=4.7 && <5
     , binary >=0.8.5 && <0.9
@@ -94,7 +94,7 @@ executable mqtt-watch
   build-depends:
       QuickCheck >=2.12.6.1 && <2.15
     , async >=2.2.1 && <2.3
-    , attoparsec >=0.13.2 && <0.15
+    , attoparsec >=0.13.2 && <0.14
     , attoparsec-binary >=0.2 && <1.0
     , base >=4.7 && <5
     , binary >=0.8.5 && <0.9
@@ -125,7 +125,7 @@ test-suite mqtt-test
       HUnit
     , QuickCheck >=2.12.6.1 && <2.15
     , async >=2.2.1 && <2.3
-    , attoparsec >=0.13.2 && <0.15
+    , attoparsec >=0.13.2 && <0.14
     , attoparsec-binary >=0.2 && <1.0
     , base >=4.7 && <5
     , binary >=0.8.5 && <0.9

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                net-mqtt
-version:             0.8.1.0
+version:             0.8.1.1
 github:              "dustin/mqtt-hs"
 license:             BSD3
 author:              "Dustin Sallings"
@@ -27,7 +27,7 @@ dependencies:
 - binary               >= 0.8.5 && < 0.9
 - containers           >= 0.5.0 && < 0.7
 - stm                  >= 2.4.0 && < 2.6
-- attoparsec           >= 0.13.2 && < 0.15
+- attoparsec           >= 0.13.2 && < 0.14
 - conduit              >= 1.3.1 && < 1.4
 - conduit-extra        >= 1.3.0 && < 1.4
 - network-conduit-tls  >= 1.3.2 && < 1.4


### PR DESCRIPTION
Hey,

With the current bounds, this package fails to build with Cabal, but works with Stack.
It looks like the current LTS in use is 18.6, which depends on `attoparsec-0.13.2.5`.
With Cabal, it tries to pull the latest version (currently 0.14.3) and the build breaks with the following output:

```haskell
src/Network/MQTT/Types.hs:279:62: error:
    • Couldn't match type ‘Data.ByteString.Internal.ByteString’
                     with ‘BL.ByteString’
      NB: ‘BL.ByteString’ is defined in ‘Data.ByteString.Lazy.Internal’
          ‘Data.ByteString.Internal.ByteString’
            is defined in ‘Data.ByteString.Internal’
      Expected type: Data.Attoparsec.Internal.Types.Parser
                       Data.ByteString.Internal.ByteString BL.ByteString
        Actual type: A.Parser Data.ByteString.Internal.ByteString
    • In the second argument of ‘(=<<)’, namely ‘A.take len’
      In a stmt of a 'do' block:
        either fail pure . A.parseOnly (A.many' parseProperty)
          =<< A.take len
      In the expression:
        do len <- decodeVarInt
           either fail pure . A.parseOnly (A.many' parseProperty)
             =<< A.take len
    |
279 |   either fail pure . A.parseOnly (A.many' parseProperty) =<< A.take len
    |                                                              ^^^^^^^^^^

src/Network/MQTT/Types.hs:717:13: error:
    • Couldn't match expected type ‘BL.ByteString’
                  with actual type ‘Data.ByteString.Internal.ByteString’
      NB: ‘Data.ByteString.Internal.ByteString’
            is defined in ‘Data.ByteString.Internal’
          ‘BL.ByteString’ is defined in ‘Data.ByteString.Lazy.Internal’
    • In the first argument of ‘subp’, namely ‘content’
      In a stmt of a 'do' block: a <- subp content
      In the expression:
        do _ <- A.word8 b
           hl <- parseHdrLen
           pid <- aWord16
           props <- parseProperties prot
           ....
    |
717 |   a <- subp content
    |             ^^^^^^^
cabal: Failed to build net-mqtt-0.8.1.0 (which is required by exe:mqtt-watch
from net-mqtt-0.8.1.0 and exe:mqtt-example from net-mqtt-0.8.1.0).
```

Restricting attoparsec's upper bound to <0.14 fixes the issue and both build systems work as intended.