### PR TITLE
Update `default.nix`

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,1 @@
+(import ./default.nix {}).shell


### PR DESCRIPTION
I wasn't able to open `nix-shell` and saw that `default.nix` had not been updated in some time. This PR just gives the nix default file a face lift, `nix-shell` now works for me.

I checked that there were no issues with `stack build` or `cabal *-build` and I don't believe this should affect the git CI workflow at all.