### PR TITLE
Allow attoparsec 0.14

### DIFF
--- a/net-mqtt.cabal
+++ b/net-mqtt.cabal
@@ -39,7 +39,7 @@ library
   build-depends:
       QuickCheck >=2.12.6.1 && <2.15
     , async >=2.2.1 && <2.3
-    , attoparsec >=0.13.2 && <0.14
+    , attoparsec >=0.13.2 && <0.15
     , attoparsec-binary >=0.2 && <1.0
     , base >=4.7 && <5
     , binary >=0.8.5 && <0.9
@@ -66,7 +66,7 @@ executable mqtt-example
   build-depends:
       QuickCheck >=2.12.6.1 && <2.15
     , async >=2.2.1 && <2.3
-    , attoparsec >=0.13.2 && <0.14
+    , attoparsec >=0.13.2 && <0.15
     , attoparsec-binary >=0.2 && <1.0
     , base >=4.7 && <5
     , binary >=0.8.5 && <0.9
@@ -94,7 +94,7 @@ executable mqtt-watch
   build-depends:
       QuickCheck >=2.12.6.1 && <2.15
     , async >=2.2.1 && <2.3
-    , attoparsec >=0.13.2 && <0.14
+    , attoparsec >=0.13.2 && <0.15
     , attoparsec-binary >=0.2 && <1.0
     , base >=4.7 && <5
     , binary >=0.8.5 && <0.9
@@ -125,7 +125,7 @@ test-suite mqtt-test
       HUnit
     , QuickCheck >=2.12.6.1 && <2.15
     , async >=2.2.1 && <2.3
-    , attoparsec >=0.13.2 && <0.14
+    , attoparsec >=0.13.2 && <0.15
     , attoparsec-binary >=0.2 && <1.0
     , base >=4.7 && <5
     , binary >=0.8.5 && <0.9

--- a/package.yaml
+++ b/package.yaml
@@ -27,7 +27,7 @@ dependencies:
 - binary               >= 0.8.5 && < 0.9
 - containers           >= 0.5.0 && < 0.7
 - stm                  >= 2.4.0 && < 2.6
-- attoparsec           >= 0.13.2 && < 0.14
+- attoparsec           >= 0.13.2 && < 0.15
 - conduit              >= 1.3.1 && < 1.4
 - conduit-extra        >= 1.3.0 && < 1.4
 - network-conduit-tls  >= 1.3.2 && < 1.4

--- a/src/Network/MQTT/Types.hs
+++ b/src/Network/MQTT/Types.hs
@@ -30,6 +30,7 @@ module Network.MQTT.Types (
 import           Control.Applicative             (liftA2, (<|>))
 import           Control.Monad                   (replicateM, when)
 import           Data.Attoparsec.Binary          (anyWord16be, anyWord32be)
+import qualified Data.Attoparsec.ByteString      as AS
 import qualified Data.Attoparsec.ByteString.Lazy as A
 import           Data.Binary.Put                 (putWord32be, runPut)
 import           Data.Bits                       (Bits (..), shiftL, testBit, (.&.), (.|.))
@@ -276,7 +277,7 @@ parseProperties :: ProtocolLevel -> A.Parser [Property]
 parseProperties Protocol311 = pure mempty
 parseProperties Protocol50 = do
   len <- decodeVarInt
-  either fail pure . A.parseOnly (A.many' parseProperty) =<< A.take len
+  either fail pure . AS.parseOnly (A.many' parseProperty) =<< A.take len
 
 -- | MQTT Protocol Levels
 data ProtocolLevel = Protocol311 -- ^ MQTT 3.1.1
@@ -717,7 +718,7 @@ parseSubHdr b prot p = do
   a <- subp content
   pure (pid, props, a)
 
-    where subp = either fail pure . A.parseOnly p
+    where subp = either fail pure . AS.parseOnly p
 
 parseSubscribe :: ProtocolLevel -> A.Parser MQTTPkt
 parseSubscribe prot = do


### PR DESCRIPTION
Hey,

The current bounds prevent using the latest version of attoparsec.
The only breaking change between versions 0.13 and 0.14 of attoparsec is that the `parseOnly` functions from lazy modules now actually require lazy inputs (as explained[ in this PR](https://github.com/haskell/attoparsec/pull/175)).

This PR maintains the current behavior in a forward compatible manner.