### PR TITLE
Make wildcard matches spec-compliant

### DIFF
--- a/src/Network/MQTT/Topic.hs
+++ b/src/Network/MQTT/Topic.hs
@@ -69,9 +69,10 @@ match :: Filter -> Topic -> Bool
 match (Filter pat) (Topic top) = cmp (splitOn "/" pat) (splitOn "/" top)
 
   where
-    cmp [] []   = True
-    cmp [] _    = False
-    cmp _ []    = False
+    cmp [] []       = True
+    cmp [] _        = False
+    cmp ["#"] []    = False
+    cmp _ []        = False
     cmp ["#"] (t:_) = not $ "$" `isPrefixOf` t
     cmp (p:ps) (t:ts)
       | p == t = cmp ps ts

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -81,7 +81,7 @@ prop_PropertiesRT p = case A.parse (parseProperties Protocol50) (bsProps Protoco
 testTopicMatching :: [TestTree]
 testTopicMatching = let allTopics = ["a", "a/b", "a/b/c/d", "b/a/c/d",
                                      "$SYS/a/b", "a/$SYS/b"]
-                        tsts = [("a", ["a"]), ("a/#", ["a/b", "a/b/c/d"]),
+                        tsts = [("a", ["a"]), ("a/#", ["a", "a/b", "a/b/c/d"]),
                                 ("+/b", ["a/b"]),
                                 ("+/+/c/+", ["a/b/c/d", "b/a/c/d"]),
                                 ("+/+/b", []),


### PR DESCRIPTION
The `match` function is not fully compliant with the [spec](http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718107), namely:

> ·        “sport/#” also matches the singular “sport”, since # includes the parent level.
> ·         “#” is valid and will receive every Application Message

This should resolve that issue.