### PR TITLE
Update text bounds to allow GHC 9.4

### DIFF
--- a/net-mqtt.cabal
+++ b/net-mqtt.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.7.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
 name:           net-mqtt
-version:        0.8.2.4
+version:        0.8.2.5
 synopsis:       An MQTT Protocol Implementation.
 description:    Please see the README on GitHub at <https://github.com/dustin/mqtt-hs#readme>
 category:       Network
@@ -52,7 +52,7 @@ library
     , network-conduit-tls >=1.3.2 && <1.4
     , network-uri >=2.6.1 && <2.7
     , stm >=2.4.0 && <2.6
-    , text >=1.2.3 && <1.3
+    , text >=1.2.3 && <2.1.0
     , websockets >=0.12.5.3 && <0.13
   default-language: Haskell2010
 
@@ -80,7 +80,7 @@ executable mqtt-example
     , network-conduit-tls >=1.3.2 && <1.4
     , network-uri >=2.6.1 && <2.7
     , stm >=2.4.0 && <2.6
-    , text >=1.2.3 && <1.3
+    , text >=1.2.3 && <2.1.0
     , websockets >=0.12.5.3 && <0.13
   default-language: Haskell2010
 
@@ -109,7 +109,7 @@ executable mqtt-watch
     , network-uri >=2.6.1 && <2.7
     , optparse-applicative
     , stm >=2.4.0 && <2.6
-    , text >=1.2.3 && <1.3
+    , text >=1.2.3 && <2.1.0
     , websockets >=0.12.5.3 && <0.13
   default-language: Haskell2010
 
@@ -145,6 +145,6 @@ test-suite mqtt-test
     , tasty
     , tasty-hunit
     , tasty-quickcheck
-    , text >=1.2.3 && <1.3
+    , text >=1.2.3 && <2.1.0
     , websockets >=0.12.5.3 && <0.13
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                net-mqtt
-version:             0.8.2.4
+version:             0.8.2.5
 github:              "dustin/mqtt-hs"
 license:             BSD3
 author:              "Dustin Sallings"
@@ -23,7 +23,7 @@ dependencies:
 - base                 >= 4.7 && < 5
 - async                >= 2.2.1 && < 2.3
 - bytestring           >= 0.10.8 && < 0.12
-- text                 >= 1.2.3 && < 1.3
+- text                 >= 1.2.3 && < 2.1.0
 - binary               >= 0.8.5 && < 0.9
 - containers           >= 0.5.0 && < 0.7
 - stm                  >= 2.4.0 && < 2.6


### PR DESCRIPTION
Minor update here, I bumped the `text` upper bound to `2.1.0`, this allows GHC 9.4.x to be used.