### PR TITLE
Expire correlated callbacks and inflight QoS2 ACKs after some time

### DIFF
--- a/net-mqtt.cabal
+++ b/net-mqtt.cabal
@@ -53,7 +53,7 @@ library
     , network-uri >=2.6.1 && <2.7
     , stm >=2.4.0 && <2.6
     , text >=1.2.3 && <2.1.0
-    , time >=1.10
+    , time >=1.9
     , websockets >=0.12.5.3 && <0.13
   default-language: Haskell2010
 
@@ -82,7 +82,7 @@ executable mqtt-example
     , network-uri >=2.6.1 && <2.7
     , stm >=2.4.0 && <2.6
     , text >=1.2.3 && <2.1.0
-    , time >=1.10
+    , time >=1.9
     , websockets >=0.12.5.3 && <0.13
   default-language: Haskell2010
 
@@ -112,7 +112,7 @@ executable mqtt-watch
     , optparse-applicative
     , stm >=2.4.0 && <2.6
     , text >=1.2.3 && <2.1.0
-    , time >=1.10
+    , time >=1.9
     , websockets >=0.12.5.3 && <0.13
   default-language: Haskell2010
 
@@ -149,6 +149,6 @@ test-suite mqtt-test
     , tasty-hunit
     , tasty-quickcheck
     , text >=1.2.3 && <2.1.0
-    , time >=1.10
+    , time >=1.9
     , websockets >=0.12.5.3 && <0.13
   default-language: Haskell2010

--- a/net-mqtt.cabal
+++ b/net-mqtt.cabal
@@ -27,6 +27,7 @@ source-repository head
 
 library
   exposed-modules:
+      Data.Map.Strict.Decaying
       Network.MQTT.Arbitrary
       Network.MQTT.Client
       Network.MQTT.Topic
@@ -53,6 +54,7 @@ library
     , stm >=2.4.0 && <2.6
     , text >=1.2.3 && <2.1.0
     , websockets >=0.12.5.3 && <0.13
+    , time > 1.10
   default-language: Haskell2010
 
 executable mqtt-example

--- a/net-mqtt.cabal
+++ b/net-mqtt.cabal
@@ -53,8 +53,8 @@ library
     , network-uri >=2.6.1 && <2.7
     , stm >=2.4.0 && <2.6
     , text >=1.2.3 && <2.1.0
+    , time >=1.10
     , websockets >=0.12.5.3 && <0.13
-    , time > 1.10
   default-language: Haskell2010
 
 executable mqtt-example
@@ -82,6 +82,7 @@ executable mqtt-example
     , network-uri >=2.6.1 && <2.7
     , stm >=2.4.0 && <2.6
     , text >=1.2.3 && <2.1.0
+    , time >=1.10
     , websockets >=0.12.5.3 && <0.13
   default-language: Haskell2010
 
@@ -111,6 +112,7 @@ executable mqtt-watch
     , optparse-applicative
     , stm >=2.4.0 && <2.6
     , text >=1.2.3 && <2.1.0
+    , time >=1.10
     , websockets >=0.12.5.3 && <0.13
   default-language: Haskell2010
 
@@ -147,5 +149,6 @@ test-suite mqtt-test
     , tasty-hunit
     , tasty-quickcheck
     , text >=1.2.3 && <2.1.0
+    , time >=1.10
     , websockets >=0.12.5.3 && <0.13
   default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -37,7 +37,7 @@ dependencies:
 - QuickCheck           >= 2.12.6.1 && < 2.15
 - websockets           >= 0.12.5.3 && < 0.13
 - crypton-connection   >= 0.3.0
-- time                 >= 1.10
+- time                 >= 1.9
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -37,6 +37,7 @@ dependencies:
 - QuickCheck           >= 2.12.6.1 && < 2.15
 - websockets           >= 0.12.5.3 && < 0.13
 - crypton-connection   >= 0.3.0
+- time                 >= 1.10
 
 library:
   source-dirs: src

--- a/src/Data/Map/Strict/Decaying.hs
+++ b/src/Data/Map/Strict/Decaying.hs
@@ -1,0 +1,60 @@
+module Data.Map.Strict.Decaying
+  ( Map,
+    new,
+    insert,
+    delete,
+    findWithDefault,
+    updateLookupWithKey,
+  )
+where
+
+import Control.Concurrent.Async (async, cancel, link)
+import Control.Concurrent.STM (STM, atomically)
+import Control.Concurrent.STM.TVar
+  ( TVar,
+    mkWeakTVar,
+    modifyTVar',
+    newTVarIO,
+    readTVar,
+    writeTVar
+  )
+import Control.Exception (mask)
+import Control.Monad (forever, void)
+import qualified Data.Map.Strict as Map
+import Data.Time (NominalDiffTime)
+import Data.Time.Clock.POSIX (POSIXTime, getPOSIXTime)
+import GHC.Conc (threadDelay, unsafeIOToSTM)
+
+data Item a = Item {_itemTime :: {-# UNPACK #-} !POSIXTime, itemValue :: !a}
+
+newtype Map k a = Map (TVar (Map.Map k (Item a)))
+
+insert :: Ord k => k -> v -> Map k v -> STM ()
+insert k v (Map m) = do
+  t <- unsafeIOToSTM getPOSIXTime
+  modifyTVar' m (Map.insert k (Item t v))
+
+delete :: Ord k => k -> Map k v -> STM ()
+delete k (Map m) = modifyTVar' m (Map.delete k)
+
+findWithDefault :: Ord k => v -> k -> Map k v -> STM v
+findWithDefault d k (Map m) = itemValue . Map.findWithDefault (Item 0 d) k <$> readTVar m
+
+updateLookupWithKey ::
+  Ord k => (k -> a -> Maybe a) -> k -> Map k a -> STM (Maybe a)
+updateLookupWithKey f k (Map m) = do
+  t <- unsafeIOToSTM getPOSIXTime
+  (mItem, m') <- Map.updateLookupWithKey (\k -> fmap (Item t) . f k . itemValue) k <$> readTVar m
+  writeTVar m $! m'
+  pure (itemValue <$> mItem)
+
+new :: NominalDiffTime -> IO (Map k a)
+new maxAge = mask $ \restore -> do
+  var <- newTVarIO Map.empty
+  reaper <- restore $ async $ forever $ do
+    now <- getPOSIXTime
+    atomically $ modifyTVar' var $ Map.filter $ \(Item t _) -> now - t < maxAge
+    threadDelay $ truncate $ maxAge / 4
+  link reaper
+  void $ mkWeakTVar var $ cancel reaper
+  pure $ Map var


### PR DESCRIPTION
This is so that correlated callbacks that are never called and QoS2 acks which aren't backed by the broker don't accumulate 