### PR TITLE
refactor: Use less brittle TLS settings construction

### DIFF
--- a/net-mqtt.cabal
+++ b/net-mqtt.cabal
@@ -49,6 +49,7 @@ library
     , conduit-extra >=1.3.0 && <1.5
     , containers >=0.5.0 && <0.7
     , crypton-connection >=0.3.0
+    , data-default-class
     , deepseq >=1.4.3.0 && <1.5
     , monad-loops >=0.4.3
     , network-conduit-tls ==1.4.*

--- a/src/Network/MQTT/Client.hs
+++ b/src/Network/MQTT/Client.hs
@@ -56,6 +56,7 @@ import           Data.Conduit.Attoparsec    (conduitParser)
 import qualified Data.Conduit.Combinators   as C
 import           Data.Conduit.Network       (AppData, appSink, appSource, clientSettings, runTCPClient)
 import           Data.Conduit.Network.TLS   (runTLSClient, tlsClientConfig, tlsClientTLSSettings)
+import           Data.Default.Class         (def)
 import           Data.Foldable              (traverse_)
 import           Data.Map.Strict            (Map)
 import qualified Data.Map.Strict            as Map
@@ -157,7 +158,10 @@ mqttConfig = MQTTConfig{_hostname="", _port=1883, _connID="",
                         _msgCB=NoCallback,
                         _protocol=Protocol311, _connProps=mempty,
                         _connectTimeout=180000000,
-                        _tlsSettings=TLSSettingsSimple False False False,
+                        _tlsSettings=def
+                          {settingDisableCertificateValidation=False,
+                           settingDisableSession=False,
+                           settingUseServerName=False},
                         _pingPeriod=30000000,
                         _pingPatience=90000000}
 


### PR DESCRIPTION
This change uses a record update on the default TLSSettings, to prevent
changes in available settings causing build failures.

For example, crypton-connection added a 'settingClientSupported' field
to 'TLSSettings'.
